### PR TITLE
Changed convert_split implementation

### DIFF
--- a/onnx2keras/converter.py
+++ b/onnx2keras/converter.py
@@ -112,7 +112,7 @@ def onnx_to_keras(onnx_model, input_names,
 
         if len(node.output) != 1:
             logger.warning('Trying to convert multi-output node')
-            node_params['_outputs'] = node.output
+            node_params['_outputs'] = list(node.output)
 
         logger.debug('######')
         logger.debug('...')

--- a/onnx2keras/utils.py
+++ b/onnx2keras/utils.py
@@ -34,8 +34,11 @@ def ensure_tf_type(obj, fake_input_layer=None):
         if obj.dtype == np.int64:
             obj = np.int32(obj)
 
-        def target_layer(_, inp=obj):
+        def target_layer(_, inp=obj, dtype=obj.dtype.name):
+            import numpy as np
             import tensorflow as tf
+            if not isinstance(inp, (np.ndarray, np.generic)):
+                inp = np.array(inp, dtype=dtype)
             return tf.constant(inp, dtype=inp.dtype, verify_shape=True)
 
         lambda_layer = keras.layers.Lambda(target_layer)


### PR DESCRIPTION
First of all: thank you for this useful project.

The previously added `convert_split` function did not conform to the ONNX specifications.
I replaced it with a version that should be correct. Additionally it should be a bit more efficient as the previous version called `tf.split` for each split followed by getting a slice, whereas this implementation skips the tf.split part and just does the slicing.

I also added two minor patches (If requested i could split them into different PRs):
- The change in `ensure_tf_type` is required because when saving and reloading as h5 file some variable which where ndarrays at creation time weren't anymore on reload time, but instead scalars and lists.
- The wrapping of `node.output` is required because otherwise it is a `google.protobuf.pyext._message.RepeatedScalarContainer` class which can't get jsonified which leads to problems when used inside a LambdaLayer when trying to save the model.