### PR TITLE
Fixes for name_policy ( Fixes #7 )

### DIFF
--- a/onnx2keras/activation_layers.py
+++ b/onnx2keras/activation_layers.py
@@ -15,7 +15,7 @@ def convert_relu(node, params, layers, node_name, keras_name):
     if len(node.input) != 1:
         assert AttributeError('More than 1 input for an activation layer.')
 
-    input_0 = ensure_tf_type(layers[node.input[0]])
+    input_0 = ensure_tf_type(layers[node.input[0]], name="%s_const" % keras_name)
 
     relu = keras.layers.Activation('relu', name=keras_name)
     layers[node_name] = relu(input_0)
@@ -34,7 +34,7 @@ def convert_lrelu(node, params, layers, node_name, keras_name):
     if len(node.input) != 1:
         assert AttributeError('More than 1 input for an activation layer.')
 
-    input_0 = ensure_tf_type(layers[node.input[0]])
+    input_0 = ensure_tf_type(layers[node.input[0]], name="%s_const" % keras_name)
 
     leakyrelu = \
         keras.layers.LeakyReLU(alpha=params['alpha'], name=keras_name)
@@ -54,7 +54,7 @@ def convert_sigmoid(node, params, layers, node_name, keras_name):
     if len(node.input) != 1:
         assert AttributeError('More than 1 input for an activation layer.')
 
-    input_0 = ensure_tf_type(layers[node.input[0]])
+    input_0 = ensure_tf_type(layers[node.input[0]], name="%s_const" % keras_name)
 
     sigmoid = keras.layers.Activation('sigmoid', name=keras_name)
     layers[node_name] = sigmoid(input_0)
@@ -73,7 +73,7 @@ def convert_tanh(node, params, layers, node_name, keras_name):
     if len(node.input) != 1:
         assert AttributeError('More than 1 input for an activation layer.')
 
-    input_0 = ensure_tf_type(layers[node.input[0]])
+    input_0 = ensure_tf_type(layers[node.input[0]], name="%s_const" % keras_name)
 
     tanh = keras.layers.Activation('tanh', name=keras_name)
     layers[node_name] = tanh(input_0)
@@ -92,7 +92,7 @@ def convert_selu(node, params, layers, node_name, keras_name):
     if len(node.input) != 1:
         assert AttributeError('More than 1 input for an activation layer.')
 
-    input_0 = ensure_tf_type(layers[node.input[0]])
+    input_0 = ensure_tf_type(layers[node.input[0]], name="%s_const" % keras_name)
 
     selu = keras.layers.Activation('selu', name=keras_name)
     layers[node_name] = selu(input_0)
@@ -111,7 +111,7 @@ def convert_softmax(node, params, layers, node_name, keras_name):
     if len(node.input) != 1:
         assert AttributeError('More than 1 input for an activation layer.')
 
-    input_0 = ensure_tf_type(layers[node.input[0]])
+    input_0 = ensure_tf_type(layers[node.input[0]], name="%s_const" % keras_name)
 
     softmax = keras.layers.Activation('softmax', name=keras_name)
     layers[node_name] = softmax(input_0)

--- a/onnx2keras/convolution_layers.py
+++ b/onnx2keras/convolution_layers.py
@@ -31,7 +31,7 @@ def convert_conv(node, params, layers, node_name, keras_name):
     else:
         raise NotImplementedError('Not implemented')
 
-    input_0 = ensure_tf_type(layers[node.input[0]])
+    input_0 = ensure_tf_type(layers[node.input[0]], name="%s_const" % keras_name)
     n_groups = params['group'] if 'group' in params else 1
     dilation = params['dilations'][0] if 'dilations' in params else 1
     pads = params['pads'] if 'pads' in params else [0, 0]
@@ -154,7 +154,7 @@ def convert_convtranspose(node, params, layers, node_name, keras_name):
     else:
         raise NotImplementedError('Not implemented')
 
-    input_0 = ensure_tf_type(layers[node.input[0]])
+    input_0 = ensure_tf_type(layers[node.input[0]], name="%s_const" % keras_name)
 
     if len(W.shape) == 5:  # 3D conv
         raise NotImplementedError('Not implemented')

--- a/onnx2keras/elementwise_layers.py
+++ b/onnx2keras/elementwise_layers.py
@@ -19,8 +19,8 @@ def convert_elementwise_div(node, params, layers, node_name, keras_name):
         raise AttributeError('Number of inputs is not equal 2 for element-wise layer')
 
     logger.debug('Convert inputs to Keras/TF layers if needed.')
-    input_0 = ensure_tf_type(layers[node.input[0]], layers[list(layers)[0]])
-    input_1 = ensure_tf_type(layers[node.input[1]], layers[list(layers)[0]])
+    input_0 = ensure_tf_type(layers[node.input[0]], layers[list(layers)[0]], name="%s_const1" % keras_name)
+    input_1 = ensure_tf_type(layers[node.input[1]], layers[list(layers)[0]], name="%s_const2" % keras_name)
 
     def target_layer(x):
         import tensorflow as tf
@@ -50,8 +50,8 @@ def convert_elementwise_add(node, params, layers, node_name, keras_name):
         raise AttributeError('Number of inputs is not equal 2 for element-wise layer')
 
     logger.debug('Convert inputs to Keras/TF layers if needed.')
-    input_0 = ensure_tf_type(layers[node.input[0]], layers[list(layers)[0]])
-    input_1 = ensure_tf_type(layers[node.input[1]], layers[list(layers)[0]])
+    input_0 = ensure_tf_type(layers[node.input[0]], layers[list(layers)[0]], name="%s_const1" % keras_name)
+    input_1 = ensure_tf_type(layers[node.input[1]], layers[list(layers)[0]], name="%s_const2" % keras_name)
 
     try:
         add = keras.layers.Add(name=keras_name)
@@ -89,8 +89,8 @@ def convert_elementwise_mul(node, params, layers, node_name, keras_name):
         raise AttributeError('Number of inputs is not equal 2 for element-wise layer')
 
     logger.debug('Convert inputs to Keras/TF layers if needed.')
-    input_0 = ensure_tf_type(layers[node.input[0]], layers[list(layers)[0]])
-    input_1 = ensure_tf_type(layers[node.input[1]], layers[list(layers)[0]])
+    input_0 = ensure_tf_type(layers[node.input[0]], layers[list(layers)[0]], name="%s_const1" % keras_name)
+    input_1 = ensure_tf_type(layers[node.input[1]], layers[list(layers)[0]], name="%s_const2" % keras_name)
 
     try:
         mul = keras.layers.Multiply(name=keras_name)
@@ -129,8 +129,8 @@ def convert_elementwise_sub(node, params, layers, node_name, keras_name):
         raise AttributeError('Number of inputs is not equal 2 for element-wise layer')
 
     logger.debug('Convert inputs to Keras/TF layers if needed.')
-    input_0 = ensure_tf_type(layers[node.input[0]], layers[list(layers)[0]])
-    input_1 = ensure_tf_type(layers[node.input[1]], layers[list(layers)[0]])
+    input_0 = ensure_tf_type(layers[node.input[0]], layers[list(layers)[0]], name="%s_const1" % keras_name)
+    input_1 = ensure_tf_type(layers[node.input[1]], layers[list(layers)[0]], name="%s_const2" % keras_name)
 
     try:
         sub = keras.layers.Subtract(name=keras_name)

--- a/onnx2keras/normalization_layers.py
+++ b/onnx2keras/normalization_layers.py
@@ -15,7 +15,7 @@ def convert_batchnorm(node, params, layers, node_name, keras_name):
     """
     logger = logging.getLogger('onnx2keras:batchnorm2d')
 
-    input_0 = ensure_tf_type(layers[node.input[0]])
+    input_0 = ensure_tf_type(layers[node.input[0]], name="%s_const" % keras_name)
 
     if len(node.input) == 5:
         weights = [
@@ -65,7 +65,7 @@ def convert_instancenorm(node, params, layers, node_name, keras_name):
     """
     logger = logging.getLogger('onnx2keras:instancenorm2d')
 
-    input_0 = ensure_tf_type(layers[node.input[0]])
+    input_0 = ensure_tf_type(layers[node.input[0]], name="%s_const" % keras_name)
 
     if len(node.input) == 3:
         gamma = ensure_numpy_type(layers[node.input[1]])
@@ -102,7 +102,7 @@ def convert_dropout(node, params, layers, node_name, keras_name):
     """
     logger = logging.getLogger('onnx2keras:dropout')
 
-    input_0 = ensure_tf_type(layers[node.input[0]])
+    input_0 = ensure_tf_type(layers[node.input[0]], name="%s_const" % keras_name)
 
     ratio = params['ratio'] if 'ratio' in params else 0.0
     lambda_layer = keras.layers.Dropout(ratio, name=keras_name)

--- a/onnx2keras/operation_layers.py
+++ b/onnx2keras/operation_layers.py
@@ -19,7 +19,7 @@ def convert_clip(node, params, layers, node_name, keras_name):
     if len(node.input) != 1:
         assert AttributeError('More than 1 input for clip layer.')
 
-    input_0 = ensure_tf_type(layers[node.input[0]])
+    input_0 = ensure_tf_type(layers[node.input[0]], name="%s_const" % keras_name)
 
     if params['min'] == 0:
         logger.debug("Using ReLU({0}) instead of clip".format(params['max']))
@@ -46,7 +46,7 @@ def convert_log(node, params, layers, node_name, keras_name):
     if len(node.input) != 1:
         assert AttributeError('More than 1 input for log layer.')
 
-    input_0 = ensure_tf_type(layers[node.input[0]])
+    input_0 = ensure_tf_type(layers[node.input[0]], name="%s_const" % keras_name)
 
     def target_layer(x):
         import keras.backend as K
@@ -68,7 +68,7 @@ def convert_exp(node, params, layers, node_name, keras_name):
     if len(node.input) != 1:
         assert AttributeError('More than 1 input for log layer.')
 
-    input_0 = ensure_tf_type(layers[node.input[0]])
+    input_0 = ensure_tf_type(layers[node.input[0]], name="%s_const" % keras_name)
 
     def target_layer(x):
         import keras.backend as K
@@ -91,7 +91,7 @@ def convert_reduce_sum(node, params, layers, node_name, keras_name):
     if len(node.input) != 1:
         assert AttributeError('More than 1 input for reduce sum layer.')
 
-    input_0 = ensure_tf_type(layers[node.input[0]])
+    input_0 = ensure_tf_type(layers[node.input[0]], name="%s_const" % keras_name)
 
     axis = params['axes']
 
@@ -117,7 +117,7 @@ def convert_reduce_mean(node, params, layers, node_name, keras_name):
     if len(node.input) != 1:
         assert AttributeError('More than 1 input for reduce mean layer.')
 
-    input_0 = ensure_tf_type(layers[node.input[0]])
+    input_0 = ensure_tf_type(layers[node.input[0]], name="%s_const" % keras_name)
 
     def target_layer(x, axis=params['axes'], keepdims=params['keepdims']):
         import keras.backend as K
@@ -141,7 +141,7 @@ def convert_pow(node, params, layers, node_name, keras_name):
     if len(node.input) != 2:
         assert AttributeError('More than 2 inputs for pow layer.')
 
-    input_0 = ensure_tf_type(layers[node.input[0]])
+    input_0 = ensure_tf_type(layers[node.input[0]], name="%s_const" % keras_name)
     power = ensure_numpy_type(layers[node.input[1]])
 
     def target_layer(x, a=power):
@@ -165,7 +165,7 @@ def convert_sqrt(node, params, layers, node_name, keras_name):
     if len(node.input) != 1:
         assert AttributeError('More than 1 input for sqrt layer.')
 
-    input_0 = ensure_tf_type(layers[node.input[0]])
+    input_0 = ensure_tf_type(layers[node.input[0]], name="%s_const" % keras_name)
 
     def target_layer(x):
         import keras.backend as K
@@ -175,7 +175,7 @@ def convert_sqrt(node, params, layers, node_name, keras_name):
     layers[node_name] = lambda_layer(input_0)
 
 
-def convert_split(node, params, layers, node_name, keras_name):
+def convert_split(node, params, layers, node_name, keras_names):
     """
     Convert Split layer
     :param node: current operation node
@@ -188,7 +188,7 @@ def convert_split(node, params, layers, node_name, keras_name):
     if len(node.input) != 1:
         assert AttributeError('More than 1 input for split layer.')
 
-    input_0 = ensure_tf_type(layers[node.input[0]])
+    input_0 = ensure_tf_type(layers[node.input[0]], name="%s_const" % keras_names[0])
     splits = params["split"]
     axis = params.get("axis", 0)
     if not isinstance(splits, Iterable):
@@ -205,7 +205,7 @@ def convert_split(node, params, layers, node_name, keras_name):
             slices[axis] = slice(start_i, end_i)
             return x[tuple(slices)]
 
-        lambda_layer = keras.layers.Lambda(target_layer, name=keras_name)
+        lambda_layer = keras.layers.Lambda(target_layer, name=keras_names[i])
         layers[node_name] = lambda_layer(input_0)
         cur += split
 
@@ -223,7 +223,7 @@ def convert_max(node, params, layers, node_name, keras_name):
     if len(node.input) != 2:
         assert AttributeError('More than 2 inputs for pow layer.')
 
-    input_0 = ensure_tf_type(layers[node.input[0]])
-    input_1 = ensure_tf_type(layers[node.input[1]])
+    input_0 = ensure_tf_type(layers[node.input[0]], name="%s_const1" % keras_name)
+    input_1 = ensure_tf_type(layers[node.input[1]], name="%s_const2" % keras_name)
 
     layers[node_name] = keras.layers.Maximum(name=keras_name)([input_0, input_1])

--- a/onnx2keras/padding_layers.py
+++ b/onnx2keras/padding_layers.py
@@ -14,7 +14,7 @@ def convert_padding(node, params, layers, node_name, keras_name):
     """
     # It's binary by-default
     params['mode'] = params['mode'].decode('ascii')
-    input_0 = ensure_tf_type(layers[node.input[0]])
+    input_0 = ensure_tf_type(layers[node.input[0]], name="%s_const" % keras_name)
 
     if params['mode'] == 'constant':
         # raise AssertionError('Cannot convert non-constant padding')

--- a/onnx2keras/pooling_layers.py
+++ b/onnx2keras/pooling_layers.py
@@ -15,7 +15,7 @@ def convert_maxpool(node, params, layers, node_name, keras_name):
     """
     logger = logging.getLogger('onnx2keras:maxpool')
 
-    input_0 = ensure_tf_type(layers[node.input[0]], layers[list(layers)[0]])
+    input_0 = ensure_tf_type(layers[node.input[0]], layers[list(layers)[0]], name="%s_const" % keras_name)
 
     height, width = params['kernel_shape']
     stride_height, stride_width = params['strides']
@@ -23,7 +23,7 @@ def convert_maxpool(node, params, layers, node_name, keras_name):
     pads = params['pads'] if 'pads' in params else [0, 0, 0, 0]
     padding_h, padding_w, _, _ = pads
 
-    pad = 'valid' 
+    pad = 'valid'
 
     if height % 2 == 1 and width % 2 == 1 and \
             height // 2 == padding_h and width // 2 == padding_w and \
@@ -32,7 +32,7 @@ def convert_maxpool(node, params, layers, node_name, keras_name):
         logger.debug('Use `same` padding parameters.')
     else:
         logger.warning('Unable to use `same` padding. Add ZeroPadding2D layer to fix shapes.')
-        padding_name = node_name + '_pad'
+        padding_name = keras_name + '_pad'
         padding_layer = keras.layers.ZeroPadding2D(
             padding=(padding_h, padding_w),
             name=padding_name
@@ -62,7 +62,7 @@ def convert_avgpool(node, params, layers, node_name, keras_name):
     """
     logger = logging.getLogger('onnx2keras:avgpool')
 
-    input_0 = ensure_tf_type(layers[node.input[0]], layers[list(layers)[0]])
+    input_0 = ensure_tf_type(layers[node.input[0]], layers[list(layers)[0]], name="%s_const" % keras_name)
 
     height, width = params['kernel_shape']
     stride_height, stride_width = params['strides']
@@ -79,7 +79,7 @@ def convert_avgpool(node, params, layers, node_name, keras_name):
         logger.debug('Use `same` padding parameters.')
     else:
         logger.warning('Unable to use `same` padding. Add ZeroPadding2D layer to fix shapes.')
-        padding_name = node_name + '_pad'
+        padding_name = keras_name + '_pad'
         padding_layer = keras.layers.ZeroPadding2D(
             padding=(padding_h, padding_w),
             name=padding_name
@@ -109,7 +109,7 @@ def convert_global_avg_pool(node, params, layers, node_name, keras_name):
     """
     logger = logging.getLogger('onnx2keras:global_avg_pool')
 
-    input_0 = ensure_tf_type(layers[node.input[0]], layers[list(layers)[0]])
+    input_0 = ensure_tf_type(layers[node.input[0]], layers[list(layers)[0]], name="%s_const" % keras_name)
 
     global_pool = keras.layers.GlobalAveragePooling2D(data_format='channels_first', name=keras_name)
     input_0 = global_pool(input_0)

--- a/onnx2keras/reshape_layers.py
+++ b/onnx2keras/reshape_layers.py
@@ -40,7 +40,7 @@ def convert_shape(node, params, layers, node_name, keras_name):
     :return: None
     """
     logger = logging.getLogger('onnx2keras:shape')
-    input_0 = ensure_tf_type(layers[node.input[0]], layers[list(layers)[0]])
+    input_0 = ensure_tf_type(layers[node.input[0]], layers[list(layers)[0]], name="%s_const" % keras_name)
     
     logger.debug('Actual result:')
     logger.debug(np.array(input_0._keras_shape))
@@ -98,10 +98,10 @@ def convert_concat(node, params, layers, node_name, keras_name):
             import tensorflow as tf
             return tf.concat(x, axis=axis)
 
-        lambda_layer = keras.layers.Lambda(target_layer, name=node_name)
-        layers[node_name] = lambda_layer([ensure_tf_type(layers[node.input[i]], layers[list(layers)[0]]) for i in range(len(node.input))])
+        lambda_layer = keras.layers.Lambda(target_layer, name=keras_name)
+        layers[node_name] = lambda_layer([ensure_tf_type(layers[node.input[i]], layers[list(layers)[0]], name="%s_const" % keras_name) for i in range(len(node.input))])
 
-        
+
 def convert_reshape(node, params, layers, node_name, keras_name):
     """
     Convert reshape.
@@ -123,7 +123,7 @@ def convert_reshape(node, params, layers, node_name, keras_name):
             logger.debug('The first argument is numpy array. Apply np.reshape.')
             layers[node_name] = np.reshape(input_0, input_1)
         else:
-            input_0 = ensure_tf_type(layers[node.input[0]], layers[list(layers)[0]])
+            input_0 = ensure_tf_type(layers[node.input[0]], layers[list(layers)[0]], name="%s_const" % keras_name)
             logger.debug('The first argument is Keras/tf layer. Apply keras.Reshape.')
             reshape = keras.layers.Reshape(input_1[1:], name=keras_name)
             layers[node_name] = reshape(input_0)
@@ -180,7 +180,7 @@ def convert_flatten(node, params, layers, node_name, keras_name):
         raise AttributeError('Number of inputs is not equal 1 for flatten layer')
 
     logger.debug('Convert inputs to Keras/TF layers if needed.')
-    input_0 = ensure_tf_type(layers[node.input[0]], layers[list(layers)[0]])
+    input_0 = ensure_tf_type(layers[node.input[0]], layers[list(layers)[0]], name="%s_const" % keras_name)
 
     reshape = keras.layers.Reshape([-1], name=keras_name)
     layers[node_name] = reshape(input_0)
@@ -203,7 +203,7 @@ def convert_slice(node, params, layers, node_name, keras_name):
         
     logger.debug('Convert inputs to Keras/TF layers if needed.')
     
-    input_0 = ensure_tf_type(layers[node.input[0]], layers[list(layers)[0]])
+    input_0 = ensure_tf_type(layers[node.input[0]], layers[list(layers)[0]], name="%s_const" % keras_name)
     layers[node_name] = input_0
     
     axes = params["axes"][0]

--- a/onnx2keras/utils.py
+++ b/onnx2keras/utils.py
@@ -23,7 +23,7 @@ def ensure_numpy_type(obj):
         raise AttributeError('Not a numpy type.')
 
 
-def ensure_tf_type(obj, fake_input_layer=None):
+def ensure_tf_type(obj, fake_input_layer=None, name=None):
     """
     Convert to Keras Constant if needed
     :param obj: numpy / tf type
@@ -41,7 +41,7 @@ def ensure_tf_type(obj, fake_input_layer=None):
                 inp = np.array(inp, dtype=dtype)
             return tf.constant(inp, dtype=inp.dtype, verify_shape=True)
 
-        lambda_layer = keras.layers.Lambda(target_layer)
+        lambda_layer = keras.layers.Lambda(target_layer, name=name)
         return lambda_layer(fake_input_layer)
     else:
         return obj


### PR DESCRIPTION
This PR fixes #7 where the name_policy changes did lead to the same name being used for multiple layers when using multi output layers.

Additionally it adds a name for lambda layers which are the result of a `ensure_tf_type` call.
Also added proper name_policy handling in some forgotten layers.

