### PR TITLE
Fix import error for python 2.7

### DIFF
--- a/onnx2keras/operation_layers.py
+++ b/onnx2keras/operation_layers.py
@@ -2,7 +2,12 @@ import keras.layers
 import keras.backend as K
 import logging
 from .utils import ensure_tf_type, ensure_numpy_type
-from collections.abc import Iterable
+
+# Handle python 2.7 import error
+try:
+    from collections.abc import Iterable
+except ImportError:
+    from collections import Iterable
 
 
 def convert_clip(node, params, layers, node_name, keras_name):


### PR DESCRIPTION
Uses collections.abc.Iterable if available, otherwise fallback to collections.Iterable