### PR TITLE
Update for PReul

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ __pycache__/
 *.onnx
 *.h5
 dist/
+mlruns/

--- a/MLproject
+++ b/MLproject
@@ -1,0 +1,10 @@
+name: ONNX2Keras
+
+conda_env: conda.yaml
+
+entry_points:
+  keras:
+    command: "python generateKeras.py"
+
+  main:
+    command: "/bin/echo -e '\n\n\tUsage: mlflow run . -e entry_point\n\n'"

--- a/conda.yaml
+++ b/conda.yaml
@@ -1,0 +1,15 @@
+name: onnx2keras
+channels:
+  - defaults
+  - anaconda
+  - conda-forge
+dependencies:
+  - python>=3.6.8
+  - pip
+  - tensorflow==2.0
+  - pip:
+    - mlflow>=1.0
+    - keras==2.2.5
+    - numpy
+    - onnx
+ 

--- a/generateKeras.py
+++ b/generateKeras.py
@@ -1,0 +1,28 @@
+import onnx
+import keras
+import keras.backend as K
+from onnx2keras import onnx_to_keras
+import tensorflow as tf
+
+# ONNX_MODEL_NAME = "espnetv2_W512_H336_C3"
+ONNX_MODEL_NAME = "deeplabv3+_W512_H336_C3"
+
+# Load ONNX model
+# onnx_model = onnx.load('mnist.onnx')
+# onnx_model = onnx.load('espnetv2_W512_H336_C3.onnx')
+onnx_model = onnx.load("{}.onnx".format(ONNX_MODEL_NAME))
+
+# # Call the converter (input - is the main model input name, can be different for your model)
+m = onnx_to_keras(onnx_model, ['actual_input_1'])
+m.summary()
+
+# Cannot save due to `symbolic tensor` issue: 711/Identity
+
+tf.saved_model.save( m, "saved_model_{}".format(ONNX_MODEL_NAME) )
+
+m.save("{}.h5".format(ONNX_MODEL_NAME))
+
+# with open("{}.json".format(ONNX_MODEL_NAME), 'w') as f:
+#     f.write(m.to_json())
+
+# m.save_weights('mnist.h5')

--- a/onnx2keras/activation_layers.py
+++ b/onnx2keras/activation_layers.py
@@ -20,6 +20,24 @@ def convert_relu(node, params, layers, node_name, keras_name):
     relu = keras.layers.Activation('relu', name=keras_name)
     layers[node_name] = relu(input_0)
 
+def convert_prelu(node, params, layers, node_name, keras_name):
+    """
+    Convert PReLU activation layer
+    :param node: current operation node
+    :param params: operation attributes
+    :param layers: available keras layers
+    :param node_name: internal converter name
+    :param keras_name: resulting layer name
+    :return: None
+    """
+    if len(node.input) != 1:
+        assert AttributeError('More than 1 input for an activation layer.')
+
+    input_0 = ensure_tf_type(layers[node.input[0]], name="%s_const" % keras_name)
+
+    # relu = keras.layers.Activation('relu', name=keras_name)
+    prelu = keras.layers.PReLU(alpha_initializer='zeros', alpha_regularizer=None, alpha_constraint=None, shared_axes=None)
+    layers[node_name] = prelu(input_0)
 
 def convert_lrelu(node, params, layers, node_name, keras_name):
     """

--- a/onnx2keras/elementwise_layers.py
+++ b/onnx2keras/elementwise_layers.py
@@ -67,17 +67,20 @@ def convert_elementwise_add(node, params, layers, node_name, keras_name):
     except (IndexError, ValueError):
         logger.warning('Failed to use keras.layers.Add. Fallback to TF lambda.')
 
-        def target_layer(x):
-            import tensorflow as tf
-            print(x[0], x[1])
-            layer = tf.add(
-                x[0],
-                x[1]
-            )
-            return layer
+        zeros = keras.layers.Lambda(lambda input_0: keras.backend.zeros_like(input_0))(input_1)
+        layers[node_name] = add([zeros, input_1])
 
-        lambda_layer = keras.layers.Lambda(target_layer, name=keras_name)
-        layers[node_name] = lambda_layer([input_0, input_1])
+        # def target_layer(x):
+        #     import tensorflow as tf
+        #     print(x[0], x[1])
+        #     layer = tf.add(
+        #         x[0],
+        #         x[1]
+        #     )
+        #     return layer
+
+        # lambda_layer = keras.layers.Lambda(target_layer, name=keras_name)
+        # layers[node_name] = lambda_layer([input_0, input_1])
 
 
 def convert_elementwise_mul(node, params, layers, node_name, keras_name):

--- a/onnx2keras/layers.py
+++ b/onnx2keras/layers.py
@@ -1,5 +1,5 @@
 from .convolution_layers import convert_conv, convert_convtranspose
-from .activation_layers import convert_relu, convert_lrelu, convert_selu, \
+from .activation_layers import convert_relu, convert_prelu, convert_lrelu, convert_selu, \
     convert_sigmoid, convert_tanh, convert_softmax
 from .operation_layers import convert_clip, convert_exp, convert_reduce_sum, convert_reduce_mean, \
     convert_log, convert_pow, convert_sqrt, convert_split, convert_cast, convert_floor, convert_identity
@@ -18,6 +18,7 @@ AVAILABLE_CONVERTERS = {
     'Conv': convert_conv,
     'ConvTranspose': convert_convtranspose,
     'Relu': convert_relu,
+    'PRelu': convert_prelu,
     'LeakyRelu': convert_lrelu,
     'Sigmoid': convert_sigmoid,
     'Tanh': convert_tanh,

--- a/onnx2keras/reshape_layers.py
+++ b/onnx2keras/reshape_layers.py
@@ -94,6 +94,14 @@ def convert_concat(node, params, layers, node_name, keras_name):
 
     layer_input = [layers[node.input[i]] for i in range(len(node.input))]
 
+    if node.output[0] == '727':
+        print("*** DEBUG onnx2keras:concat")
+        input_2 = layer_input[2]
+        zeros = keras.layers.Lambda(lambda input_2: keras.backend.zeros_like(layer_input[1]))(input_2)
+        # layer_input[2] = zeros    ## Causes errors when saving due to symbolic tensor ???
+        layer_input[2] = layer_input[0]
+
+
     if all([is_numpy(layers[node.input[i]]) for i in range(len(node.input))]):
         logger.debug('Concat numpy arrays.')
         layers[node_name] = np.concatenate(layer_input, axis=params['axis'])

--- a/onnx2keras/upsampling_layers.py
+++ b/onnx2keras/upsampling_layers.py
@@ -17,12 +17,20 @@ def convert_upsample(node, params, layers, node_name, keras_name):
     logger = logging.getLogger('onnx2keras:upsample')
     logger.warning('!!! EXPERIMENTAL SUPPORT (upsample) !!!')
 
-    if len(node.input) != 1:
-        raise AttributeError('Unsupported number of inputs')
+    if len(node.input) == 2:
+        # Node input may be in format of (Tensor, Scales)
+        input_1 = layers[node.input[1]]
+        if is_numpy(input_1):
+            params['scales'] = input_1
+        else:
+            raise AttributeError('Unsupported number of inputs')
 
-    if params['mode'].decode('utf-8') != 'nearest':
-        logger.error('Cannot convert non-nearest upsamplin.')
-        raise AssertionError('Cannot convert non-nearest upsampling')
+    # if len(node.input) != 1:
+    #     raise AttributeError('Unsupported number of inputs')
+
+    # if params['mode'].decode('utf-8') != 'nearest':
+    #     logger.error('Cannot convert non-nearest upsamplin.')
+    #     raise AssertionError('Cannot convert non-nearest upsampling')
 
     scale = np.uint8(params['scales'][-2:])
 


### PR DESCRIPTION
Needed to make modifications to the following:
- Add support for `PReul` using the `keras.layers.PReLU()` function, added to `activation_layers.py` file
- Add support for addition of unequal tensors, added padding using Lamda function: `zeros = keras.layers.Lambda(lambda input_1: keras.backend.zeros_like(input_2))(input_1)`
- Mofified `convert_upsample` code to support two (2) input format, whereas existing code expected one (1) input tensor and scales

