### PR TITLE
In 2D conv layers, use padding='same' rather than padding layer when the case is verified

### DIFF
--- a/onnx2keras/convolution_layers.py
+++ b/onnx2keras/convolution_layers.py
@@ -82,8 +82,8 @@ def convert_conv(node, params, layers, node_name, keras_name):
 
         padding_mode = 'VALID' # Keras is case insensitive
         if pads[0] > 0 or pads[1] > 0:
-            if (strides[0] == 1 and strides[1] == 1) and (height % 2 == 1 and width % 2 == 1) and (height // 2 == pads[0] and width // 2 == pads[1]):
-                # Using 'SAME' padding instead of a padding layer when we're sure that that's the case: the kernel has stride=1 and odd dimensions and the padding is the floored half of the kernel dimension
+            if (height % 2 == 1 and width % 2 == 1) and (height // 2 == pads[0] and width // 2 == pads[1]):
+                # Using 'SAME' padding instead of a padding layer when we're sure that that's the case: the kernel has odd dimensions and the padding is the floored half of the kernel dimension
                 padding_mode = 'SAME'
             else:
                 logger.debug('Paddings exist, add ZeroPadding layer')

--- a/onnx2keras/convolution_layers.py
+++ b/onnx2keras/convolution_layers.py
@@ -80,12 +80,12 @@ def convert_conv(node, params, layers, node_name, keras_name):
         height, width, channels_per_group, out_channels = W.shape
         in_channels = channels_per_group * n_groups
 
+        padding_mode = 'VALID' # Keras is case insensitive
         if pads[0] > 0 or pads[1] > 0:
             if (strides[0] == 1 and strides[1] == 1) and (height % 2 == 1 and width % 2 == 1) and (height // 2 == pads[0] and width // 2 == pads[1]):
                 # Using 'SAME' padding instead of a padding layer when we're sure that that's the case: the kernel has stride=1 and odd dimensions and the padding is the floored half of the kernel dimension
                 padding_mode = 'SAME'
             else:
-                padding_mode = 'VALID' # Keras is case insensitive
                 logger.debug('Paddings exist, add ZeroPadding layer')
                 padding_name = keras_name + '_pad'
                 padding_layer = keras.layers.ZeroPadding2D(


### PR DESCRIPTION
What I did was:

- Changed the hardcoded instances of `padding='valid'` and `padding='VALID'` to a variable called `padding_mode`, assigned with `'VALID'` (Keras is case-insensitive. TF might be sensitive).

- Skipping the 2D padding layer and setting `padding_mode='SAME'` if and only if:
    - the padding equals to the conv kernel dimension divided by 2 and floored (e.g. padding=1 when size = 3, padding = 2 when size = 5, padding = 3 when size = 7, etc.) 
   - the conv kernel has odd dimensions (since for an even-sized kernel, it is not well defined where the padding should be added for a "same" padding)

I hope this is an acceptable change from your side. 