### PR TITLE
Fix a part of slice conversion

### DIFF
--- a/onnx2keras/reshape_layers.py
+++ b/onnx2keras/reshape_layers.py
@@ -308,15 +308,16 @@ def convert_slice(node, params, layers, node_name, keras_name):
                     assert AttributeError('Cant slice permuted axes')
 
         if isinstance(axes, list) or isinstance(axes, np.ndarray):
-            def target_layer(x, axes=axes, starts=starts, ends=ends):
-                import tensorflow as tf
-                return tf.strided_slice(x, starts, ends)
-
-            #lambda_layer = keras.layers.Lambda(target_layer, name=keras_name)
-            #layers[node_name] = lambda_layer(input_0)
-            print('#'*70)
-            if axes == 1:
+            if axes == 0:
+                layers[node_name] = input_0[starts[0]:ends[0]]
+            elif axes == 1:
                 layers[node_name] = input_0[:, starts[0]:ends[0]]
+            elif axes == 2:
+                layers[node_name] = input_0[:, :, starts[0]:ends[0]]
+            elif axes == 3:
+                layers[node_name] = input_0[:, :, :, starts[0]:ends[0]]
+            else:
+                raise AttributeError('Not implemented')
         else:
             if axes == 0:
                 def target_layer(x):

--- a/onnx2keras/reshape_layers.py
+++ b/onnx2keras/reshape_layers.py
@@ -349,7 +349,6 @@ def convert_slice(node, params, layers, node_name, keras_name):
                 layers[node_name] = lambda_layer(input_0)
             else:
                 raise AttributeError('Not implemented')
-    from IPython import embed; embed()
 
 
 def convert_squeeze(node, params, layers, node_name, keras_name):

--- a/onnx2keras/reshape_layers.py
+++ b/onnx2keras/reshape_layers.py
@@ -41,7 +41,7 @@ def convert_shape(node, params, layers, node_name, keras_name):
     """
     logger = logging.getLogger('onnx2keras:shape')
     input_0 = ensure_tf_type(layers[node.input[0]], layers[list(layers)[0]], name="%s_const" % keras_name)
-    
+
     logger.debug('Actual shape:')
     logger.debug(np.array(input_0.shape))
 
@@ -257,7 +257,7 @@ def convert_flatten(node, params, layers, node_name, keras_name):
         reshape = keras.layers.Reshape([-1], name=keras_name)
         layers[node_name] = reshape(input_0)
 
-   
+
 def convert_slice(node, params, layers, node_name, keras_name):
     """
     Convert slice.
@@ -312,8 +312,11 @@ def convert_slice(node, params, layers, node_name, keras_name):
                 import tensorflow as tf
                 return tf.strided_slice(x, starts, ends)
 
-            lambda_layer = keras.layers.Lambda(target_layer, name=keras_name)
-            layers[node_name] = lambda_layer(input_0)
+            #lambda_layer = keras.layers.Lambda(target_layer, name=keras_name)
+            #layers[node_name] = lambda_layer(input_0)
+            print('#'*70)
+            if axes == 1:
+                layers[node_name] = input_0[:, starts[0]:ends[0]]
         else:
             if axes == 0:
                 def target_layer(x):
@@ -345,6 +348,7 @@ def convert_slice(node, params, layers, node_name, keras_name):
                 layers[node_name] = lambda_layer(input_0)
             else:
                 raise AttributeError('Not implemented')
+    from IPython import embed; embed()
 
 
 def convert_squeeze(node, params, layers, node_name, keras_name):


### PR DESCRIPTION
Hi @nerox8664 , thank you for your work.
When I was converting a model from chainer to keras via ONNX with `onnx2keras`, some indexing function didn't work well. And the fundamental reason seemed to be in `tf.strided_slice()`.
Instead of using `tf.strided_slice()`, I use index variables directly. It works well.
(If you want detailed explanations, I'll do.)

Here, I fixed the bug and tested both my environment and `test/layers/reshapes/slice.py`.

My environment is:
* Python 3.6.3
* ONNX 1.6.0
* tensorflow 2.1.0
* chainer 7.2.0
([Here](https://drive.google.com/open?id=1MMyeZQ7iPuOrGUbyiE-orb9tQbqW45gu) is my onnx model made by chainer, please check if you need.)

I hope my work can help make your tools more useful!!

