### PR TITLE
Fix for convert_cast

### DIFF
--- a/onnx2keras/operation_layers.py
+++ b/onnx2keras/operation_layers.py
@@ -263,7 +263,7 @@ def convert_cast(node, params, layers, lambda_func, node_name, keras_name):
             11: np.double,
         }
 
-        layers[node_name] = cast_map[params['to']](node.input[0])
+        layers[node_name] = cast_map[params['to']](layers[node.input[0]])
     else:
         input_0 = ensure_tf_type(layers[node.input[0]], name="%s_const" % keras_name)
 


### PR DESCRIPTION
Problem: casting to a type in case the values ​​are represented in the form of a numpy array were performed not over the values ​​of the layer, but over the index of this layer. 
For example:
If:
```
node.input = ["11"]
layers = {
...,
"11": [120, 130], - numpy array of np.in32
...
}
```
Then after this line of code:
```
layers[node_name] = cast_map[params['to']](node.input[0])
```
layers["11"] will become [11] instead of numpy array of desired type with values [120.0, 130.0].