### PR TITLE
Fix an axis issue for Concatenate layer

### DIFF
--- a/onnx2keras/converter.py
+++ b/onnx2keras/converter.py
@@ -200,7 +200,7 @@ def onnx_to_keras(onnx_model, input_names,
     if change_ordering:
         change_ord_axes_map = {
             3: 2,
-            1: 3,
+            1: -1,
             -1: 1
         }
 


### PR DESCRIPTION
I encountered this error `IndexError: list assignment index out of range` when converting an `onnx` model from [Github Linzaer/Ultra-Light-Fast-Generic-Face-Detector-1MB](https://github.com/Linzaer/Ultra-Light-Fast-Generic-Face-Detector-1MB) project to keras `h5`.
- First `git clone` the project and `cd` into it.
- Run conversion:
  ```py
  import onnx
  from onnx2keras import onnx_to_keras
  onnx_model = onnx.load('models/onnx/version-slim-320_without_postprocessing.onnx')
  mm = onnx_to_keras(onnx_model, [onnx_model.graph.input[0].name], name_policy="renumerate", change_ordering=True)
  # /opt/anaconda3/lib/python3.7/site-packages/tensorflow/python/keras/layers/merge.py in build(self, input_shape)
  #     499     for i in range(len(reduced_inputs_shapes)):
  # --> 500       del reduced_inputs_shapes[i][self.axis]
  # IndexError: list assignment index out of range
  ```
  The printed shape of that `reduced_inputs_shapes` and `self.axis` in `keras/layers/merge.py` is `[[None, 2, 3600], [None, 2, 600], [None, 2, 160], [None, 2, 60]]` and `3`
- Changing this `1: 3` to `1: -1` solves my problem, and after this, the printed `reduced_inputs_shapes` and `self.axis` is `[[None, 2, 3600], [None, 2, 600], [None, 2, 160], [None, 2, 60]]` and `-1`. But I don't know if this has other impacts...